### PR TITLE
Force display

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,9 @@ popd
 cp ./assets/qlcplus /etc/init.d/qlcplus
 systemctl daemon-reload
 
+# QLC+ needs there to be a display available or it will crash on launch
+sed -ie "s|#hdmi_force_hotplug=1|hdmi_force_hotplug=1|g" /boot/config.txt
+
 # Add settings for BitWiard DMX board to config.txt
 # https://bitwizard.nl/wiki/Dmx_interface_for_raspberry_pi
 {


### PR DESCRIPTION
Uncomment hdmi_force_hotplug in config.txt so there is always a display available to QLC+. Without a display it crashes on launch with this error:

```
EGL Error : Could not create the egl surface: error = 0x300b
```